### PR TITLE
Clean labels of Prisma2 repositories

### DIFF
--- a/src/labels/common/prisma2.ts
+++ b/src/labels/common/prisma2.ts
@@ -46,18 +46,6 @@ export const common = {
     color: colors.kind,
     description: 'Developer asked a question. No code changes required.',
   },
-  'scope/l': {
-    color: colors.scope,
-    description: 'This is a large issue that requires thoughtful planning.',
-  },
-  'scope/m': {
-    color: colors.scope,
-    description: 'Scope is uncertain and still needs to be thought through',
-  },
-  'scope/s': {
-    color: colors.scope,
-    description: "This is a small issue that doesn't require much thought.",
-  },
   'status/thinking': {
     color: colors.status,
     description:

--- a/src/labels/common/prisma2.ts
+++ b/src/labels/common/prisma2.ts
@@ -78,26 +78,6 @@ export const common = {
     color: colors.release,
     description: 'Prisma Preview release 8',
   },
-  'area/query-engine': {
-    color: colors.area,
-    description: 'Query engine related',
-  },
-  'area/migration-engine': {
-    color: colors.area,
-    description: 'Migration engine related',
-  },
-  'area/schema': {
-    color: colors.area,
-    description: 'Prisma Schema related',
-  },
-  'area/studio': {
-    color: colors.area,
-    description: 'Prisma Studio related',
-  },
-  'area/cli': {
-    color: colors.area,
-    description: 'Prisma CLI related',
-  },
   candidate: {
     color: colors.area,
     description: 'candidate for the next release',

--- a/src/labels/common/prisma2.ts
+++ b/src/labels/common/prisma2.ts
@@ -46,18 +46,6 @@ export const common = {
     color: colors.kind,
     description: 'Developer asked a question. No code changes required.',
   },
-  'priority/high': {
-    color: colors.priority,
-    description: 'This issue should be prioritized over other issues.',
-  },
-  'priority/mid': {
-    color: colors.priority,
-    description: 'Still needs to be prioritized',
-  },
-  'priority/low': {
-    color: colors.priority,
-    description: 'Other issues should be prioritized over this issue.',
-  },
   'scope/l': {
     color: colors.scope,
     description: 'This is a large issue that requires thoughtful planning.',

--- a/src/labels/common/prisma2.ts
+++ b/src/labels/common/prisma2.ts
@@ -34,10 +34,6 @@ export const common = {
     description:
       'A new request or an improvement to existing code. Code will need to be added or removed.',
   },
-  'kind/duplicate': {
-    color: colors.kind,
-    description: 'A duplicate issue',
-  },
   'kind/docs': {
     color: colors.kind,
     description: 'A documentation change is required.',

--- a/src/labels/common/prisma2.ts
+++ b/src/labels/common/prisma2.ts
@@ -46,18 +46,6 @@ export const common = {
     color: colors.kind,
     description: 'Developer asked a question. No code changes required.',
   },
-  'team/product': {
-    color: colors.team,
-    description: 'This issue is owned by the product team',
-  },
-  'team/content': {
-    color: colors.team,
-    description: 'This issue is owned by the content team',
-  },
-  'team/engineering': {
-    color: colors.team,
-    description: 'This issue is owned by the engineering team',
-  },
   'release/preview1': {
     color: colors.release,
     description: 'Prisma Preview release 1',

--- a/src/labels/common/prisma2.ts
+++ b/src/labels/common/prisma2.ts
@@ -46,38 +46,6 @@ export const common = {
     color: colors.kind,
     description: 'Developer asked a question. No code changes required.',
   },
-  'release/preview1': {
-    color: colors.release,
-    description: 'Prisma Preview release 1',
-  },
-  'release/preview2': {
-    color: colors.release,
-    description: 'Prisma Preview release 2',
-  },
-  'release/preview3': {
-    color: colors.release,
-    description: 'Prisma Preview release 3',
-  },
-  'release/preview4': {
-    color: colors.release,
-    description: 'Prisma Preview release 4',
-  },
-  'release/preview5': {
-    color: colors.release,
-    description: 'Prisma Preview release 5',
-  },
-  'release/preview6': {
-    color: colors.release,
-    description: 'Prisma Preview release 6',
-  },
-  'release/preview7': {
-    color: colors.release,
-    description: 'Prisma Preview release 7',
-  },
-  'release/preview8': {
-    color: colors.release,
-    description: 'Prisma Preview release 8',
-  },
   candidate: {
     color: colors.area,
     description: 'candidate for the next release',

--- a/src/labels/common/prisma2.ts
+++ b/src/labels/common/prisma2.ts
@@ -46,37 +46,6 @@ export const common = {
     color: colors.kind,
     description: 'Developer asked a question. No code changes required.',
   },
-  'status/thinking': {
-    color: colors.status,
-    description:
-      "We're thinking about this issue and haven't made any decisions yet",
-  },
-  'status/needs-response': {
-    color: colors.status,
-    description: 'We are waiting for a response before continuing.',
-  },
-  'status/upcoming': {
-    color: colors.status,
-    description: 'This issue will be resolved in an upcoming release',
-  },
-  'status/unplanned': {
-    color: colors.status,
-    description:
-      'No plan to fix this in any specific release. Please discuss with us before working on this issue.',
-  },
-  'status/pr-welcome': {
-    color: colors.status,
-    description:
-      'No plans to work on this but would happily accept a PR for this change.',
-  },
-  'status/stale': {
-    color: colors.status,
-    description: 'Marked as state by the GitHub stalebot',
-  },
-  'status/blocked': {
-    color: colors.status,
-    description: 'Depends on another issue which is blocking this one.',
-  },
   'team/product': {
     color: colors.team,
     description: 'This issue is owned by the product team',


### PR DESCRIPTION
This PR removes all the labels we decided to remove (temporarily or permanently) to simplify the Issue Triage and Preview planning processes.

Merging this should just remove the labels from the affected repos, correct?