### PR TITLE
Add label for regressions

### DIFF
--- a/src/labels/common/prisma2.ts
+++ b/src/labels/common/prisma2.ts
@@ -29,6 +29,10 @@ export const common = {
     color: colors.kind,
     description: 'A reported bug',
   },
+  'kind/regression': {
+    color: colors.kind,
+    description: 'A reported bug in functionality that used to work before',
+  },
   'kind/feature': {
     color: colors.kind,
     description:


### PR DESCRIPTION
This adds a new `kind/regression` label that has the same general meaning as `kind/bug` (and is also qualified via the `bug/*` labels) but has the added meaning that it appeared in functionality that used to work fine before.