### PR TITLE
Prisma2: Use `reduceAreas` for area labels again

### DIFF
--- a/src/labels/repositories/specs.ts
+++ b/src/labels/repositories/specs.ts
@@ -1,31 +1,36 @@
 // import { common } from '../common/prisma2'
 import { colors } from '../common/prisma2'
-// import { reduceAreas } from '../../utils'
+import { reduceAreas } from '../../utils'
 import { RepositoryConfig } from 'label-sync-core'
 
-const areas: string[] = []
+const areas: string[] = [
+  'area/photonjs',
+  'area/lift',
+  'area/schema',
+  'area/cli',
+  'area/introspection',
+  'area/sdk',
+  'area/studio',
+  'area/query-engine',
+  'area/migration-engine',
+  'area/spec-infra',
+  'area/spec-meta',
+  'area/process', 
+  'area/connector',
+]
 
 export const specs: RepositoryConfig = {
   labels: {
-    // ...common,
+    // ...common, // no common labels for specs
+    // status
     'status/1-needs-info': { color: colors.status },
     'status/2-wait-for-spec': { color: colors.status },
     'status/3-spec-in-progress': { color: colors.status },
-    'area/photonjs': { color: colors.area },
-    'area/lift': { color: colors.area },
-    'area/schema': { color: colors.area },
-    'area/cli': { color: colors.area },
-    'area/introspection': { color: colors.area },
-    'area/sdk': { color: colors.area },
-    'area/studio': { color: colors.area },
-    'area/query-engine': { color: colors.area },
-    'area/migration-engine': { color: colors.area },
-    'area/spec-infra': { color: colors.area },
-    'area/process': { color: colors.area }, 
-    'area/connector': { color: colors.area },
+    // when
     'when/build-before-ga': { color: colors.priority },
     'when/clarify-before-ga': { color: colors.priority },
     'when/far-future': { color: colors.priority },
+    // process
     'process/candidate': { 
       color: colors.process,
       description: 'candidate for the next milestone',
@@ -34,7 +39,7 @@ export const specs: RepositoryConfig = {
       color: colors.process,
       description: 'issue earmarked for next milestone',
     },
-    // ...reduceAreas(areas),
+    ...reduceAreas(areas),
   },
   strict: true,
 }


### PR DESCRIPTION
We didn't use `reduceAreas` for Prisma2 yet, but it makes sense to do so.

(Also add `area/spec-meta`)