### PR TITLE
feat: add lab labels

### DIFF
--- a/src/labels/index.ts
+++ b/src/labels/index.ts
@@ -18,6 +18,7 @@ import { prisma2Private } from './repositories/prisma2-private'
 import { prismaSdkJs } from './repositories/prisma-sdk-js'
 import { prismaEngine } from './repositories/prisma-engine'
 import { vscodePrisma } from './repositories/vscode-prisma'
+import oss from './repositories/oss'
 
 const config: Config = {
   // prisma 1
@@ -29,7 +30,7 @@ const config: Config = {
   'prisma/graphqlgen': graphqlgen,
   'prisma/prisma-binding': prismaBinding,
   'graphql-binding/graphql-binding': graphqlBinding,
-  
+
   // prisma 2
   'prisma/studio': studio,
   'prisma/photonjs': photonjs,
@@ -41,6 +42,8 @@ const config: Config = {
   'prisma/prisma-engine': prismaEngine,
   'prisma/vscode-prisma': vscodePrisma,
 
+  // other
+  ...oss,
 }
 
 export default config

--- a/src/labels/repositories/oss.ts
+++ b/src/labels/repositories/oss.ts
@@ -1,0 +1,130 @@
+import { toLabelSync, Label } from '../../utils'
+
+const theme = {
+  neutral: '#EEEEEE',
+}
+
+/**
+ * Based off conventional commit notion of type. The kind of issue.
+ * These labels may get their own colour to help visually differentiate
+ * between them faster. The commit that closes this issue should generally
+ * be of the same type as this label.
+ */
+const type = (name: string, color: string, description?: string): Label => ({
+  name: `community/${name}`,
+  color,
+  description,
+})
+
+/**
+ * Based off conventional commit notion of scope. What area of
+ * the project does the issue touch. The commit that closes this issue
+ * should generally be of the same scope as this label.
+ */
+const scope = (name: string, description?: string): Label => ({
+  name: `scope/${name}`,
+  color: '#3267c9',
+  description,
+})
+
+/**
+ * Scrum story-pointing labels that help us track how complex an issue
+ * is. Complexity rating is generally not transferable between teams.
+ */
+const complexity = (name: string, description?: string): Label => ({
+  name: `complexity/${name}`,
+  color: theme.neutral,
+  description,
+})
+
+/**
+ * Labels that help us track how impactful issues will be. Combined
+ * with complexity label, helps inform prioritization.
+ */
+const impact = (name: string, description?: string): Label => ({
+  name: `impact/${name}`,
+  color: theme.neutral,
+  description,
+})
+
+/**
+ * Labels that help us mark issues as being on hold for some reason.
+ */
+const needs = (name: string, description?: string): Label => ({
+  name: `needs/${name}`,
+  color: '#FFE601',
+  description,
+})
+
+/**
+ * Labels that help us coordinate with the community.
+ */
+const community = (name: string, description?: string): Label => ({
+  name: `community/${name}`,
+  color: '#7057ff',
+  description,
+})
+
+/**
+ * Labels that help us track issue short-circuites or other minimal
+ * categorical details.
+ */
+const note = (name: string, description?: string): Label => ({
+  name: `note/${name}`,
+  color: theme.neutral,
+  description,
+})
+
+const common: Label[] = [
+  type('bug', '#D73A4A'),
+  type('chore', theme.neutral),
+  type('feature', '#3BDB8D'),
+  type('discussion', '#f0b3fc'),
+  type('perf', '#FFCF2D'),
+  impact('1', 'All users will benefit'),
+  impact('2', 'Many users will benefit'),
+  impact('3', 'A few users will benefit'),
+  complexity('1', 'skateboard'),
+  complexity('2', 'bicycle'),
+  complexity('3', 'motorcycle'),
+  complexity('5', 'truck'),
+  complexity('8', 'hovercraft'),
+  complexity('13', 'spaceship'),
+  needs('clarification', 'Unable to answer question/feature without more info'),
+  needs(
+    'use-cases',
+    'More motivating examples needed to understand/appreciate idea/tradeoffs',
+  ),
+  needs('investigation', 'Possibly an issue, needs more analysis/research'),
+  community('help-wanted', 'Not our focus, but accepting PRs'),
+  community('good-first-issue', 'Good for newcomers'),
+  note('invalid', 'Initial assumptions turned out wrong'),
+  note('wontfix', 'Resolving the issue was explicitly ruled out'),
+  note('duplicate', 'This issue existed already'),
+  scope('error-handling', 'Relates to error types, messages, capturing, ...'),
+  scope(
+    'docs',
+    'Relates to knowledge transfer matter (refs, guides, tuts, examples, ...)',
+  ),
+  scope('cicd', 'Relates to process automations'),
+]
+
+export default toLabelSync({
+  'prisma/nexus-prisma': [
+    ...common,
+    scope('auth', 'Relates to Prisma crud/model auth'),
+    scope('generation', 'Relates to typegen/codegen systems'),
+    scope('publishing', 'Relates to Prisma crud/model publishing'),
+    scope('resolving', 'Relates to implementing resolvers'),
+    note(
+      'prisma-1',
+      'specific to the version of nexus-prisma based on Prisma 1',
+    ),
+  ],
+  'prisma/nexus': [
+    ...common,
+    scope('auth', 'Relates to authorization and/or authentication'),
+    scope('gql-spec', 'Relates to coverage of the GraphQL Spec'),
+    scope('generation', 'Relates to typegen system'),
+  ],
+})

--- a/src/labels/repositories/oss.ts
+++ b/src/labels/repositories/oss.ts
@@ -11,7 +11,7 @@ const theme = {
  * be of the same type as this label.
  */
 const type = (name: string, description: string, color: string): Label => ({
-  name: `community/${name}`,
+  name: `type/${name}`,
   color,
   description,
 })

--- a/src/labels/repositories/oss.ts
+++ b/src/labels/repositories/oss.ts
@@ -10,7 +10,7 @@ const theme = {
  * between them faster. The commit that closes this issue should generally
  * be of the same type as this label.
  */
-const type = (name: string, color: string, description?: string): Label => ({
+const type = (name: string, description: string, color: string): Label => ({
   name: `community/${name}`,
   color,
   description,
@@ -76,14 +76,22 @@ const note = (name: string, description?: string): Label => ({
 })
 
 const common: Label[] = [
-  type('bug', '#D73A4A'),
-  type('chore', theme.neutral),
-  type('feature', '#3BDB8D'),
-  type('discussion', '#f0b3fc'),
-  type('perf', '#FFCF2D'),
-  impact('1', 'All users will benefit'),
-  impact('2', 'Many users will benefit'),
-  impact('3', 'A few users will benefit'),
+  type('bug', 'Something is not working the way it should', '#D73A4A'),
+  type(
+    'chore',
+    'Something that does not directly impact the user/runtime',
+    '#EEEEEE',
+  ),
+  type('feature', 'Add a new capability or enhance an existing one', '#3BDB8D'),
+  type(
+    'discussion',
+    'Open-ended conversation about something (ideation, design, analysis, ...)',
+    '#f0b3fc',
+  ),
+  type('perf', 'Improve the efficiency of something', '#FFCF2D'),
+  impact('high', 'All users will benefit'),
+  impact('medium', 'Many users will benefit'),
+  impact('low', 'A few users will benefit'),
   complexity('1', 'skateboard'),
   complexity('2', 'bicycle'),
   complexity('3', 'motorcycle'),

--- a/src/labels/repositories/oss.ts
+++ b/src/labels/repositories/oss.ts
@@ -84,9 +84,9 @@ const common: Label[] = [
   ),
   type('feature', 'Add a new capability or enhance an existing one', '#3BDB8D'),
   type(
-    'discussion',
-    'Open-ended conversation about something (ideation, design, analysis, ...)',
-    '#f0b3fc',
+    'refactor',
+    'Address tech debt, internal incidental complexity',
+    '#fcaeec',
   ),
   type('perf', 'Improve the efficiency of something', '#FFCF2D'),
   impact('high', 'All users will benefit'),
@@ -98,6 +98,10 @@ const common: Label[] = [
   complexity('5', 'truck'),
   complexity('8', 'hovercraft'),
   complexity('13', 'spaceship'),
+  needs(
+    'discussion',
+    'Open-ended conversation about something (ideation, design, analysis, ...)',
+  ),
   needs('clarification', 'Unable to answer question/feature without more info'),
   needs(
     'use-cases',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { RepositoryConfig, LabelConfig } from 'label-sync-core'
 import { colors } from './labels/common/prisma1'
 
 export function reduceAreas(areas: string[]) {
@@ -7,4 +8,44 @@ export function reduceAreas(areas: string[]) {
       [area]: colors.area,
     }
   }, {})
+}
+export type Index<T> = Record<string, T>
+
+export type RepositoryConfigs = Index<RepositoryConfig>
+
+export type LabelConfigs = Index<LabelConfig>
+
+export type Label = {
+  name: string
+  color: string
+  description?: string
+}
+
+type ReposToLabels = Index<Label[]>
+
+/**
+ * Map the internal repo-to-labels data representation
+ * to what label-sync-core expects.
+ */
+export const toLabelSync = (repos: ReposToLabels): RepositoryConfigs => {
+  return Object.entries(repos).reduce<RepositoryConfigs>(
+    (repos, [repoName, labels]) => {
+      return {
+        ...repos,
+        [repoName]: {
+          labels: labels.reduce<LabelConfigs>((labels, label) => {
+            return {
+              ...labels,
+              [label.name]: {
+                // "#" prefix permits vscode extensions to colorize color values
+                color: label.color.replace(/^#(.*)/, '$1'),
+                description: label.description,
+              },
+            }
+          }, {}),
+        },
+      }
+    },
+    {},
+  )
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,13 +29,13 @@ type ReposToLabels = Index<Label[]>
  */
 export const toLabelSync = (repos: ReposToLabels): RepositoryConfigs => {
   return Object.entries(repos).reduce<RepositoryConfigs>(
-    (repos, [repoName, labels]) => {
+    (repositoryConfigs, [repoName, repoLabels]) => {
       return {
-        ...repos,
+        ...repositoryConfigs,
         [repoName]: {
-          labels: labels.reduce<LabelConfigs>((labels, label) => {
+          labels: repoLabels.reduce<LabelConfigs>((labelConfigs, label) => {
             return {
-              ...labels,
+              ...labelConfigs,
               [label.name]: {
                 // "#" prefix permits vscode extensions to colorize color values
                 color: label.color.replace(/^#(.*)/, '$1'),


### PR DESCRIPTION
A first pass at labels for nexus and nexus-prisma. I think these will go through many iterations over the coming weeks/months.

I think sharing as much as we can across all Prisma repos makes sense. For example while I think `type/` is better than `area/` because it aligns with well known conventional commit terminology, it is not worth it if we cannot migrate `area/` over.

I built a micro DSL for readability and maintainability reasons.

#### todo

- [x] descriptions for `type` labels
- [x] `impact/` `high | medium | low`
- [ ] figure out what to do with `polish`
- [ ] figure out what to do with `question`
- [ ] figure out what to do with `support`
- [ ] figure out what to do with `types`